### PR TITLE
CBK-141

### DIFF
--- a/frontend/src/components/JournalEditingModal.js
+++ b/frontend/src/components/JournalEditingModal.js
@@ -196,7 +196,12 @@ export default function CustomizedDialogs({
                 );
                 await updateJournals();
                 setIsSaving(false);
-                handleEdit(false);
+                if (privacy==="PRIVATE") {
+                    handleClose();
+                } else {
+                    // instead of close the modal, switch to viewing mode
+                    handleEdit(false);
+                }
             }
         } catch (err) {
             setIsSaving(false);

--- a/frontend/src/components/JournalEditingModal.js
+++ b/frontend/src/components/JournalEditingModal.js
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect } from 'react';
+import { useLocation } from 'react-router-dom'
 import { useState } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
@@ -122,6 +123,7 @@ export default function CustomizedDialogs({
     const [title, setTitle] = useState(journal.title);
     const [isSaving, setIsSaving] = useState(false);
     const auth = useContext(AuthContext);
+    const route = useLocation();
 
     const handleLocation = (loc) => {
         setLocation(loc);
@@ -196,7 +198,7 @@ export default function CustomizedDialogs({
                 );
                 await updateJournals();
                 setIsSaving(false);
-                if (privacy==="PRIVATE") {
+                if (privacy==="PRIVATE" && route.pathname==='/') {
                     handleClose();
                 } else {
                     // instead of close the modal, switch to viewing mode


### PR DESCRIPTION
When user is on explore tab, close the modal when set the privacy to private instead of showing viewing modal, to avoid flashing in explore tab.